### PR TITLE
Make adversarial eval quiet by default

### DIFF
--- a/src/safe_agent/cli.py
+++ b/src/safe_agent/cli.py
@@ -72,6 +72,11 @@ console = Console()
     default=None,
     help="Write adversarial evaluation markdown report to a file.",
 )
+@click.option(
+    "--adversarial-verbose",
+    is_flag=True,
+    help="Print full impact preview output during adversarial runs (default: quiet).",
+)
 @click.option("--model", default="claude-sonnet-4-20250514", help="Claude model to use")
 @click.option("--audit-export", type=click.Path(), help="Export audit trail to JSON file")
 @click.option("--compliance-mode", is_flag=True, help="Enable strict compliance mode (disables auto-approve)")
@@ -117,6 +122,7 @@ def main(
     adversarial_suite: str | None,
     adversarial_json_out: str | None,
     adversarial_markdown_out: str | None,
+    adversarial_verbose: bool,
     model: str,
     audit_export: str | None,
     compliance_mode: bool,
@@ -165,7 +171,11 @@ def main(
             run_adversarial_suite_from_file,
         )
 
-        result = run_adversarial_suite_from_file(adversarial_suite, workdir=os.getcwd())
+        result = run_adversarial_suite_from_file(
+            adversarial_suite,
+            workdir=os.getcwd(),
+            verbose=adversarial_verbose,
+        )
         markdown = render_adversarial_markdown(result)
         console.print(markdown)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ def test_adversarial_suite_runs_without_api_key() -> None:
         result = runner.invoke(main, ["--adversarial-suite", str(suite_path)])
         assert result.exit_code == 0
         assert "Safe Agent Adversarial Evaluation" in result.output
+        assert "Impact Preview" not in result.output
 
 
 def test_adversarial_suite_exits_3_when_case_fails() -> None:


### PR DESCRIPTION
## What changed
- default adversarial suite runs are now quiet (suppress Impact Preview panels)
- add `--adversarial-verbose` to opt into full per-case preview output
- add a test to ensure quiet default behavior

## Why
Keeps CI logs readable while still providing deterministic markdown/JSON reports.

## Validation
- `uv run ruff check src/safe_agent/adversarial.py src/safe_agent/cli.py tests/test_cli.py`
- `uv run pytest -q`
